### PR TITLE
Do not replace equations by 'A' in english

### DIFF
--- a/tex2txt.py
+++ b/tex2txt.py
@@ -400,7 +400,7 @@ def set_language_de():
 
 def set_language_en():
     # see comments in set_language_de()
-    parms.inline_math = ('A', 'B', 'C', 'D', 'E', 'F')
+    parms.inline_math = ('B', 'C', 'D', 'E', 'F', 'G')
     parms.display_math = ('U', 'V', 'W', 'X', 'Y', 'Z')
     parms.check_equation_replacements = False
     parms.mathoptext = {'+': ' plus ', '-': ' minus ',


### PR DESCRIPTION
'A' is a valid word in english and can lead to false positive with languagetool like:
```
Let $x$ and $y$ be things.
```
gives
```
Let F and A be things.
```
and langagetool complains:
```
1.) Line 1, column 11, Rule ID: A_INFINITVE[1]                                                                                                                                                         
Message: Maybe a wrong construction: a/the + infinitive                                                                                                                                                
Let F and A be things.                                                                                                                                                                                 
          ^^^^           
```